### PR TITLE
Improve dependency injection

### DIFF
--- a/www/js/app/lib.js
+++ b/www/js/app/lib.js
@@ -1,7 +1,9 @@
-define(['jquery'], function ($) {
-    return {
-        getBody: function () {
-            return $('body');
-        }
-    }
+define(function(){
+    return function ($) {
+        return {
+            getBody: function () {
+                return $('body');
+            }
+        };
+    };
 });

--- a/www/js/app/main1.js
+++ b/www/js/app/main1.js
@@ -1,6 +1,6 @@
 define(function (require) {
     var $ = require('jquery'),
-        lib = require('./lib'),
+        lib = require('./lib')($),
         controller = require('./controller/c1'),
         model = require('./model/m1');
 

--- a/www/js/app/main2.js
+++ b/www/js/app/main2.js
@@ -1,6 +1,6 @@
 define(function (require) {
     var $ = require('jquery'),
-        lib = require('./lib'),
+        lib = require('./lib')($),
         controller = require('./controller/c2'),
         model = require('./model/m2');
 


### PR DESCRIPTION
Improve dependency injection in lib.js to:
* Do not relay on jQuery so that it can be easily switched to use Zepto or another library with jQuery API compatible.
* Do not load two times jQuery:
  * In lib.js
  * In each mainX.js file